### PR TITLE
Removed support for teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 **GitHub Brain** is an experimental MCP server for summarizing GitHub discussions, issues, and pull requests. It helps answer questions like:
 
 - _What are the contributions of user X in the last month?_
-- _List all pull requests merged by the members of team Y in the last week._
 - _Summarize this month's discussions._
 
 https://github.com/user-attachments/assets/80910025-9d58-4367-af00-bf4c51e6ce86
@@ -67,7 +66,7 @@ The first call for an organization may take a while. Subsequent calls are faster
 | `-t`     | `GITHUB_TOKEN`          | Your GitHub [personal token](https://github.com/settings/personal-access-tokens) to access the API. **Required.**                                                             |
 | `-o`     | `ORGANIZATION`          | The GitHub organization to pull data from. **Required.**                                                                                                                      |
 | `-db`    | `DB_DIR`                | Path to the SQLite database directory. Default: `db` folder in the current directory. An `<organization>.db` file will be created here.                                       |
-| `-i`     |                         | Only pull selected entities. Choose from: `repositories`, `discussions`, `issues`, `pull-requests`, `teams`. Comma-separated list.                                            |
+| `-i`     |                         | Only pull selected entities. Choose from: `repositories`, `discussions`, `issues`, `pull-requests`. Comma-separated list.                                                     |
 | `-f`     |                         | Remove all data before pulling. If combined with `-i`, only the specified items will be removed.                                                                              |
 | `-e`     | `EXCLUDED_REPOSITORIES` | Comma-separated list of repositories to exclude from the pull of discussions, issues, and pull-requests. Useful for large repositories that are not relevant to the analysis. |
 
@@ -78,7 +77,6 @@ The first call for an organization may take a while. Subsequent calls are faster
 
     For private organizations, the token must have the following configuration:
 
-    - Organization permissions: Read access to members
     - Repository permissions: Read access to discussions, issues, metadata, and pull requests
 
     For public organizations, an empty token is sufficient, as the data is publicly accessible.

--- a/main.go
+++ b/main.go
@@ -329,7 +329,7 @@ type Config struct {
 	GithubToken           string
 	Organization          string
 	DBDir                 string
-	Items                 []string // Items to pull (repositories, discussions, issues, pull-requests, teams)
+	Items                 []string // Items to pull (repositories, discussions, issues, pull-requests)
 	Force                 bool     // Remove all data before pulling
 	ExcludedRepositories  []string // Comma-separated list of repositories to exclude from the pull of discussions, issues, and pull-requests
 }
@@ -631,7 +631,7 @@ type Progress struct {
 	rateUpdateChan    chan int
 	minInterval       time.Duration         // Minimum interval for the spinner (fastest speed)
 	maxInterval       time.Duration         // Maximum interval for the spinner (slowest speed)
-	items             map[string]itemStatus // Status of each item (repositories, discussions, issues, pull-requests, teams)
+	items             map[string]itemStatus // Status of each item (repositories, discussions, issues, pull-requests)
 	currentItem       string                // Currently processing item
 	console           *Console              // Console manager for synchronized output
 	mutex             sync.Mutex            // Mutex to protect updates to Progress fields
@@ -5147,7 +5147,7 @@ func main() {
 		args := os.Args[2:]
 		for i := 0; i < len(args); i++ {
 			if args[i] == "-h" || args[i] == "--help" {
-				fmt.Println("Usage: pull -t <token> -o <organization> [-db <dbpath>] [-i repositories,discussions,issues,pull-requests,teams] [-e excluded_repos] [-f]")
+				fmt.Println("Usage: pull -t <token> -o <organization> [-db <dbpath>] [-i repositories,discussions,issues,pull-requests] [-e excluded_repos] [-f]")
 				os.Exit(0)
 			}
 		}

--- a/main.md
+++ b/main.md
@@ -83,7 +83,7 @@ Console at the beginning of the `pull` command - all items selected:
 - **Sections**: Clear visual separation with headers and spacing
 - **Responsive Layout**: Adjust to terminal width (minimum 64 chars)
 
-Console at the beginning of the `pull` command - `-i repositories,teams`:
+Console at the beginning of the `pull` command - `-i repositories`:
 
 ```
 ┌─ GitHub 🧠 pull ─────────────────────────────────────────────┐


### PR DESCRIPTION
The [official GitHub MCP server](https://github.com/github/github-mcp-server) now supports team tools. Since team data is only accessed once per prompt for user lookup, GitHub Brain's local DB performance advantage doesn't apply here, making it safe to remove for team functionality.